### PR TITLE
Update Scrypted

### DIFF
--- a/scrypted/scrypted.xml
+++ b/scrypted/scrypted.xml
@@ -7,39 +7,19 @@
   <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
-  <Support>https://hub.docker.com/r/koush/scrypted/</Support>
+  <Support>https://github.com/koush/scrypted/issues/</Support>
   <Project>https://github.com/koush/scrypted</Project>
   <Overview>Scrypted Home Automation</Overview>
   <Category>HomeAutomation:</Category>
-  <WebUI>https://[IP]:[PORT:9443]/</WebUI>
-  <TemplateURL/>
+  <WebUI>http://[IP]:[PORT:11080]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/PTRFRLL/unraid-templates/master/scrypted/scrypted.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/PTRFRLL/unraid-templates/master/scrypted/icon.png</Icon>
-  <ExtraParams/>
+  <ExtraParams>--restart unless-stopped</ExtraParams>
   <PostArgs/>
   <CPUset/>
-  <DateInstalled>1632358488</DateInstalled>
-  <DonateText/>
-  <DonateLink/>
-  <Description>Scrypted Home Automation</Description>
-  <Networking>
-    <Mode>host</Mode>
-    <Publish>
-      <Port>
-        <HostPort>9443</HostPort>
-        <ContainerPort>9443</ContainerPort>
-        <Protocol>tcp</Protocol>
-      </Port>
-    </Publish>
-  </Networking>
-  <Data>
-    <Volume>
-      <HostDir>/mnt/user/appdata/scrypted</HostDir>
-      <ContainerDir>/server/volume</ContainerDir>
-      <Mode>rw</Mode>
-    </Volume>
-  </Data>
-  <Environment/>
-  <Labels/>
-  <Config Name="Appdata" Target="/server/volume" Default="" Mode="rw" Description="Container Path: /server/volume" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/scrypted</Config>
-  <Config Name="WebUI" Target="9443" Default="9443" Mode="tcp" Description="Container Port: " Type="Port" Display="always" Required="false" Mask="false">9443</Config>
+  <DateInstalled>1658602491</DateInstalled>
+  <DonateText>Buy me a coffee/beer</DonateText>
+  <DonateLink>https://www.paypal.me/ptrfrll</DonateLink>
+  <Requires/>
+  <Config Name="Appdata" Target="/server/volume" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/scrypted</Config>
 </Container>


### PR DESCRIPTION
- Set container to restart unless stopped to allow Scrypted's internal restart function to work
- Updated support page link to Github issues
- Fixed https port as default is to run in http/non-secured mode as it is an internal service
- Fixed template URL field
- Fixed networking as host containers do not need to define a port
- Added donate text/link for @PTRFRLL 
- Cleaned up config portion / data portion as default value is generally the correct approach unless someone has a specific config